### PR TITLE
fix: Moved progress into the player state

### DIFF
--- a/src/components/controls.svelte
+++ b/src/components/controls.svelte
@@ -1,24 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import * as Tone from 'tone';
 
-	import { getCurrentPlayer, shiftQueueIntoPlayer } from '$lib/player';
+	import { shiftQueueIntoPlayer } from '$lib/player';
 	import { playerStore } from '$lib/stores/player';
 
 	const fillColor = `hsl(var(--nc) / var(--tw-text-opacity))`;
-
-	let progress = 0;
-	let max = 0;
-
-	onMount(() => {
-		setInterval(() => {
-			if ($playerStore.paused) {
-				return;
-			}
-
-			progress = progress + 1;
-		}, 1000);
-	});
 
 	const togglePaused = () => {
 		const paused = !$playerStore.paused;
@@ -31,17 +17,6 @@
 			Tone.Transport.start();
 		}
 	};
-
-	playerStore.subscribe(() => {
-		const songDuration = getCurrentPlayer()?.buffer.duration;
-
-		if (!songDuration || max === songDuration) {
-			return;
-		}
-
-		progress = 0;
-		max = songDuration;
-	});
 </script>
 
 <div class="h-full flex flex-col gap-2">
@@ -88,6 +63,10 @@
 	</div>
 
 	<div class="flex gap-2 items-center">
-		<progress class="progress w-full" value={progress} {max} />
+		<progress
+			class="progress w-full"
+			value={$playerStore.progress}
+			max={$playerStore.currentSongDuration}
+		/>
 	</div>
 </div>

--- a/src/components/game.svelte
+++ b/src/components/game.svelte
@@ -12,16 +12,6 @@
 
 	$: handleBtnClick = $gameStore.gamestate === 'day' ? startNight : startDay;
 
-	onMount(async () => {
-		if ($gameStore.nightCount > 1) {
-			return;
-		}
-
-		showCurrentSongToast();
-
-		startFirstNightPhase();
-	});
-
 	const startNight = async () => {
 		await startNextGamePhase('night');
 

--- a/src/components/game.svelte
+++ b/src/components/game.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-
-	import { startFirstNightPhase, startNextGamePhase } from '$lib/game';
+	import { startNextGamePhase } from '$lib/game';
 	import { gameStore } from '$lib/stores/game';
 	import { playerStore } from '$lib/stores/player';
 	import { showCurrentSongToast } from '$lib/stores/toast';

--- a/src/components/setup.svelte
+++ b/src/components/setup.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import * as Tone from 'tone';
 
 	import { loadNextRandomSongForPhase } from '$lib/song';
 	import { t } from '$lib/stores/i18n';
@@ -8,7 +7,6 @@
 	import { gameStore } from '$lib/stores/game';
 
 	import Game from '../components/game.svelte';
-	import { showCurrentSongToast } from '$lib/stores/toast';
 	import { startFirstNightPhase } from '$lib/game';
 
 	$: ({ nextPhaseSong, currentPhaseSong } = $playerStore);
@@ -22,22 +20,16 @@
 		playerStore.update({ currentPhaseSong: nextPhaseSong, nextPhaseSong: undefined });
 	});
 
-	const startGame = async () => {
-		await Tone.start();
-
-		gameStore.start();
-
-		showCurrentSongToast();
-
-		startFirstNightPhase();
-	};
-
 	$: buttonLabel = currentPhaseSong ? $t('game.start') : $t('game.load');
 </script>
 
 {#if $gameStore.state !== 'running'}
 	<div class="h-full flex justify-center items-center">
-		<button disabled={!$playerStore.currentPhaseSong} on:click={startGame} class="btn btn-primary">
+		<button
+			disabled={!$playerStore.currentPhaseSong}
+			on:click={startFirstNightPhase}
+			class="btn btn-primary"
+		>
 			{buttonLabel}
 		</button>
 	</div>

--- a/src/components/setup.svelte
+++ b/src/components/setup.svelte
@@ -8,10 +8,15 @@
 	import { gameStore } from '$lib/stores/game';
 
 	import Game from '../components/game.svelte';
+	import { showCurrentSongToast } from '$lib/stores/toast';
+	import { startFirstNightPhase } from '$lib/game';
 
 	$: ({ nextPhaseSong, currentPhaseSong } = $playerStore);
 
 	onMount(async () => {
+		if ($gameStore.state == 'running') {
+			return;
+		}
 		await loadNextRandomSongForPhase('night');
 
 		playerStore.update({ currentPhaseSong: nextPhaseSong, nextPhaseSong: undefined });
@@ -21,6 +26,10 @@
 		await Tone.start();
 
 		gameStore.start();
+
+		showCurrentSongToast();
+
+		startFirstNightPhase();
 	};
 
 	$: buttonLabel = currentPhaseSong ? $t('game.start') : $t('game.load');

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -6,10 +6,17 @@ import { playerStore } from '$lib/stores/player';
 import { fadeSongs, loadNextRandomSongForPhase } from './song';
 import { startPlayer } from './player';
 
-export const startFirstNightPhase = () => {
+import * as Tone from 'tone';
+import { showCurrentSongToast } from './stores/toast';
+
+export const startFirstNightPhase = async () => {
 	const { nightPlayer } = get(playerStore);
 
-	gameStore.setState('night');
+	await Tone.start();
+
+	gameStore.start();
+
+	showCurrentSongToast();
 
 	// load next day song
 	loadNextRandomSongForPhase('day');

--- a/src/lib/stores/game.ts
+++ b/src/lib/stores/game.ts
@@ -22,7 +22,8 @@ export function createGameStateStore() {
 	const start = () => {
 		update((currentState) => ({
 			...currentState,
-			state: 'running'
+			state: 'running',
+			gamestate: 'night'
 		}));
 	};
 

--- a/src/lib/stores/player.ts
+++ b/src/lib/stores/player.ts
@@ -22,7 +22,7 @@ export type PlayerStore = {
 	};
 };
 
-let progressTimer: NodeJS.Timer;
+let progressClock: NodeJS.Timer;
 
 const createInit = (): PlayerStore => {
 	const fadeTime = 1;
@@ -65,14 +65,9 @@ export function createPlayerStore() {
 	const { subscribe, update, set } = writable<PlayerStore>(init);
 
 	const updateAction = (newState: Partial<PlayerStore>) => {
-		if (newState.paused != undefined) {
-			handlePaused(newState.paused);
-		}
-		if (newState.currentPhaseSong != undefined) {
-			clearInterval(progressTimer);
+		if (newState.currentPhaseSong !== undefined) {
 			newState.progress = 0;
 			newState.currentSongDuration = getCurrentPlayer()?.buffer.duration;
-			progressTimer = createInterval();
 		}
 
 		update((currentState) => ({ ...currentState, ...newState }));
@@ -86,20 +81,12 @@ export function createPlayerStore() {
 		set(createInit());
 	};
 
-	const handlePaused = (paused: boolean) => {
-		if (paused) {
-			clearInterval(progressTimer);
-		} else {
-			progressTimer = createInterval();
-		}
-	};
-
-	const createInterval = (): NodeJS.Timer =>
-		setInterval(() => {
-			update((currentState) => ({ ...currentState, progress: currentState.progress + 1 }));
-		}, 1000);
-
-	progressTimer = createInterval();
+	progressClock = setInterval(() => {
+		update((currentState) => ({
+			...currentState,
+			progress: currentState.progress + (currentState.paused ? 0 : 1)
+		}));
+	}, 1000);
 
 	return {
 		subscribe,


### PR DESCRIPTION
Fixes #37  by moving the progress state out of the component the component it wont get reseted on a remount.
Furthermore improve onMount methods of Setup and Game in order to not show the toast multiple times when changing the view in  the first night.