### PR TITLE
fix: Use base64url enconding 

### DIFF
--- a/src/routes/api/songs/+server.ts
+++ b/src/routes/api/songs/+server.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 export async function GET({ url }: RequestEvent) {
 	const songUrl = url.searchParams.get('url') ?? '';
-	const internalSongName = Buffer.from(songUrl, 'ascii').toString('base64');
+	const internalSongName = Buffer.from(songUrl, 'ascii').toString('base64url');
 	const songPath = './tmp/' + internalSongName + '.mp3';
 
 	if (fs.existsSync(songPath)) {


### PR DESCRIPTION
To fix bugs where the song could not be saved as the base64 resulted in an incorrect path